### PR TITLE
Allow all versions of Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.0",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*|6.0.*",
-        "illuminate/http": "5.6.*|5.7.*|5.8.*|6.0.*"
+        "illuminate/support": "5.6.*|5.7.*|5.8.*|6.*",
+        "illuminate/http": "5.6.*|5.7.*|5.8.*|6.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Due to Laravel adopting semantic versioning, allowing for all versions of 6 is the norm and will allow this package to be installed on any laravel instal until the next major update rather than having to adjust for each minor update.