### PR TITLE
Fix typehints to return the correct thing.

### DIFF
--- a/src/Slug.php
+++ b/src/Slug.php
@@ -3,7 +3,6 @@
 namespace Drobee\NovaSluggable;
 
 use Laravel\Nova\Fields\Field;
-use Laravel\Nova\Element;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class Slug extends Field
@@ -25,32 +24,32 @@ class Slug extends Field
         parent::__construct($name, $attribute, $resolveCallback);
     }
 
-    public function slugModel(string $model): Element
+    public function slugModel(string $model): self
     {
         return $this->withMeta(['model' => $model]);
     }
     
-    public function slugUnique(): Element
+    public function slugUnique(): self
     {
         return $this->setOption('generateUniqueSlugs', true);
     }
 
-    public function slugMaxLength(int $length): Element
+    public function slugMaxLength(int $length): self
     {
         return $this->setOption('maximumLength', $length);
     }
 
-    public function slugSeparator(string $separator): Element
+    public function slugSeparator(string $separator): self
     {
         return $this->setOption('slugSeparator', $separator);
     }
 
-    public function slugLanguage(string $language): Element
+    public function slugLanguage(string $language): self
     {
         return $this->setOption('slugLanguage', $language);
     }
 
-    public function event(string $eventType): Element
+    public function event(string $eventType): self
     {
         if (in_array($eventType, ['keyup', 'blur'])) {
             return $this->setOption('event', $eventType);
@@ -59,7 +58,7 @@ class Slug extends Field
         return $this->setOption('event', 'keyup');
     }
 
-    protected function setOption(string $name, string $value): Element
+    protected function setOption(string $name, string $value): self
     {
         $this->options[$name] = $value;
         return $this->withMeta(['options' => $this->options]);

--- a/src/SluggableText.php
+++ b/src/SluggableText.php
@@ -2,7 +2,6 @@
 
 namespace Drobee\NovaSluggable;
 
-use Laravel\Nova\Element;
 use Laravel\Nova\Fields\Text;
 
 class SluggableText extends Text
@@ -16,9 +15,9 @@ class SluggableText extends Text
 
     /**
      * @param string $slugField
-     * @return Element
+     * @return $this
      */
-    public function slug($slugField = 'Slug'): Element
+    public function slug($slugField = 'Slug'): self
     {
         return $this->withMeta([__FUNCTION__ => $slugField]);
     }


### PR DESCRIPTION
This PR addresses an issue where the field methods were returning `Element` rather than `$this`.

This was causing syntax highlighting and Intellisense to not work as expected:

![image](https://user-images.githubusercontent.com/199807/98834862-9b2ab280-2437-11eb-9ef6-f52c83add083.png)

This should fix that issue.